### PR TITLE
Fix Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ A repository to highlight examples of using the Chroma (vector database) with La
 ## Document Question-Answering
 
 For an example of using Chroma+LangChain to do question answering over documents, see [this notebook](qa.ipynb).
-To use a persistent database with Chroma and Langchain, see [this notebook](qa_persistent.ipynb).
+To use a persistent database with Chroma and Langchain, see [this notebook](persistent-qa.ipynb).


### PR DESCRIPTION
The link to the persistent-qa.ipynb notebook was misspelled. 